### PR TITLE
Add debug node via function and corresponding JS callback

### DIFF
--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -142,7 +142,7 @@ VIREO_FUNCTION_SIGNATURE1(FPSync, StringRef)
 }
 
 // generic implementation: debug node
-VIREO_FUNCTION_SIGNATURE1(DEBUGNODE, StringRef)
+VIREO_FUNCTION_SIGNATURE1(DebugNode, StringRef)
 {
 #if kVireoOS_emscripten
     // If on debug node Probe or breakpoint is set we do the call back else next intruction

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -22,6 +22,12 @@ extern "C" {
 }
 #endif
 
+#if kVireoOS_emscripten
+extern "C" {
+    extern void jsExecutionContextDebugNodeSync(StringRef)
+}
+#endif
+
 //------------------------------------------------------------
 Boolean ExecutionContext::_classInited;
 _PROGMEM InstructionCore ExecutionContext::_culDeSac;
@@ -134,6 +140,17 @@ VIREO_FUNCTION_SIGNATURE1(FPSync, StringRef)
 #endif
     return _NextInstruction();
 }
+
+// generic implementation: debug node
+VIREO_FUNCTION_SIGNATURE1(DEBUGNODE, StringRef)
+{
+#if kVireoOS_emscripten
+    // If on debug node Probe or breakpoint is set we do the call back else next intruction
+    jsExecutionContextDebugNodeSync(_Param(0));
+#endif
+    return _NextInstruction();
+}
+
 //------------------------------------------------------------
 //
 

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -31,10 +31,10 @@ var assignCoreHelpers;
             fpSync(fpString);
         };
 
-        Module.coreHelpers.jsExecutionContextDebugNodeSync = function (debugNodeIdentifierStringPointer) {                                                                                                                                                                                                                                                                                                                                                                                                                         
+        Module.coreHelpers.jsExecutionContextDebugNodeSync = function (debugNodeIdentifierStringPointer) {
             var debugNodeIdentifierString = Module.eggShell.dataReadString(debugNodeIdentifierStringPointer);
             debugNodeSync(debugNodeIdentifierString);
-        }
+        };
 
         Module.coreHelpers.jsSystemLogging_WriteMessageUTF8 = function (
             messageTypeRef, messageDataRef,

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -16,6 +16,11 @@ var assignCoreHelpers;
             // Dummy noop function user can replace by using eggShell.setFPSyncFunction
         };
 
+        // Private Instance Variables (per vireo instance)
+        var debugNodeSync = function (/* debugNodeIdStr*/) {
+            // Dummy noop function user can replace by using eggShell.setdebugNodeSyncFunction
+        };
+
         var CODES = {
             NO_ERROR: 0
         };
@@ -25,6 +30,11 @@ var assignCoreHelpers;
             var fpString = Module.eggShell.dataReadString(fpStringPointer);
             fpSync(fpString);
         };
+
+        Module.coreHelpers.jsExecutionContextDebugNodeSync = function (debugNodeIdentifierStringPointer) {                                                                                                                                                                                                                                                                                                                                                                                                                         
+            var debugNodeIdentifierString = Module.eggShell.dataReadString(debugNodeIdentifierStringPointer);
+            debugNodeSync(debugNodeIdentifierString);
+        }
 
         Module.coreHelpers.jsSystemLogging_WriteMessageUTF8 = function (
             messageTypeRef, messageDataRef,
@@ -55,6 +65,13 @@ var assignCoreHelpers;
             }
 
             fpSync = fn;
+        };
+
+        publicAPI.coreHelpers.setDebugNodeSyncFunction = function (fn) {
+            if (typeof fn !== 'function') {
+                throw new Error('Probe must be a callable function');
+            }
+            debugNodeSync = fn;
         };
 
         // Returns the length of a C string (excluding null terminator)


### PR DESCRIPTION
Added a new function call for DebugNode function and the corresponding JS callback to go check the type of the debug point and its validity. The JS callback can then decide the corresponding C# Debugging APIs to call.
Will add in upcoming PRs:
- Check in the dictionary whether the debug node is active before calling the js callback.
- Add the Javascript call back to add probe and breakpoint at run time in another PR.