### PR TITLE
Add debug node via function and corresponding JS callback

### DIFF
--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -11,7 +11,12 @@ namespace Vireo {
     // Debug node which will check if breakpoint is set or not
     VIREO_FUNCTION_SIGNATURE1(DebugPoint, StringRef)
     {
-        return _NextInstruction();
+        #if kVireoOS_emscripten
+            #if GetDebugPointState(_Param(0))
+                jsDebuggingContextDebugPointInterrupt(_Param(0));
+            #endif
+        #endif
+            return _NextInstruction();
     }
 
     DEFINE_VIREO_BEGIN(Execution)

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -12,9 +12,9 @@ namespace Vireo {
     VIREO_FUNCTION_SIGNATURE1(DebugPoint, StringRef)
     {
         #if kVireoOS_emscripten
-            #if GetDebugPointState(_Param(0))
+            if (GetDebugPointState(_Param(0)) {
                 jsDebuggingContextDebugPointInterrupt(_Param(0));
-            #endif
+            }
         #endif
             return _NextInstruction();
     }

--- a/source/core/DebuggingContext.cpp
+++ b/source/core/DebuggingContext.cpp
@@ -8,6 +8,9 @@
 
 #if kVireoOS_emscripten
 #include <emscripten.h>
+extern "C" {
+    extern void jsDebuggingContextDebugPointInterrupt(StringRef)
+}
 #endif
 
 namespace Vireo {

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -18,7 +18,7 @@ var assignCoreHelpers;
 
         // Private Instance Variables (per vireo instance)
         var debugPointSync = function (/* debugPointIdStr*/) {
-            // Dummy noop function user can replace by using eggShell.setdebugNodeSyncFunction
+            // Dummy noop function user can replace by using eggShell.setdebugPointSyncFunction
         };
 
         var CODES = {

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -16,6 +16,11 @@ var assignCoreHelpers;
             // Dummy noop function user can replace by using eggShell.setFPSyncFunction
         };
 
+        // Private Instance Variables (per vireo instance)
+        var debugPointSync = function (/* debugPointIdStr*/) {
+            // Dummy noop function user can replace by using eggShell.setdebugNodeSyncFunction
+        };
+
         var CODES = {
             NO_ERROR: 0
         };
@@ -26,6 +31,11 @@ var assignCoreHelpers;
             fpSync(fpString);
         };
 
+        Module.coreHelpers.jsDebuggingContextDebugPointInterrupt = function (debugPointIdentifierStringPointer) {
+            var debugPointIdentifierString = Module.eggShell.dataReadString(debugPointIdentifierStringPointer);
+            debugPointSync(debugPointIdentifierString);
+        };
+        
         Module.coreHelpers.jsSystemLogging_WriteMessageUTF8 = function (
             messageTypeRef, messageDataRef,
             severityTypeRef, severityDataRef) {
@@ -55,6 +65,13 @@ var assignCoreHelpers;
             }
 
             fpSync = fn;
+        };
+
+        publicAPI.coreHelpers.setDebugPointSyncFunction = function (fn) {
+            if (typeof fn !== 'function') {
+                throw new Error('Probe must be a callable function');
+            }
+            debugPointSync = fn;
         };
 
         // Returns the length of a C string (excluding null terminator)

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -17,8 +17,8 @@ var assignCoreHelpers;
         };
 
         // Private Instance Variables (per vireo instance)
-        var debugPointSync = function (/* debugPointIdStr*/) {
-            // Dummy noop function user can replace by using eggShell.setdebugPointSyncFunction
+        var debugPointInterrupt = function (/* debugPointIdStr*/) {
+            // Dummy noop function user can replace by using eggShell.setDebugPointInterruptFunction
         };
 
         var CODES = {
@@ -33,7 +33,7 @@ var assignCoreHelpers;
 
         Module.coreHelpers.jsDebuggingContextDebugPointInterrupt = function (debugPointIdentifierStringPointer) {
             var debugPointIdentifierString = Module.eggShell.dataReadString(debugPointIdentifierStringPointer);
-            debugPointSync(debugPointIdentifierString);
+            debugPointInterrupt(debugPointIdentifierString);
         };
 
         Module.coreHelpers.jsSystemLogging_WriteMessageUTF8 = function (
@@ -67,11 +67,11 @@ var assignCoreHelpers;
             fpSync = fn;
         };
 
-        publicAPI.coreHelpers.setDebugPointSyncFunction = function (fn) {
+        publicAPI.coreHelpers.setDebugPointInterruptFunction = function (fn) {
             if (typeof fn !== 'function') {
                 throw new Error('Probe must be a callable function');
             }
-            debugPointSync = fn;
+            debugPointInterrupt = fn;
         };
 
         // Returns the length of a C string (excluding null terminator)

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -35,7 +35,7 @@ var assignCoreHelpers;
             var debugPointIdentifierString = Module.eggShell.dataReadString(debugPointIdentifierStringPointer);
             debugPointSync(debugPointIdentifierString);
         };
-        
+
         Module.coreHelpers.jsSystemLogging_WriteMessageUTF8 = function (
             messageTypeRef, messageDataRef,
             severityTypeRef, severityDataRef) {


### PR DESCRIPTION
Added a new function call for DebugNode function and the corresponding JS callback to go check the type of the debug point and its validity. The JS callback can then decide the corresponding C# Debugging APIs to call.
Will add in upcoming PRs:

Check in the dictionary whether the debug node is active before calling the js callback.
Add the Javascript call back to add probe and breakpoint at run time in another PR.