### PR TITLE
Added the support to start and stop 

### DIFF
--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -72,7 +72,7 @@ VIREO_EXPORT Int32 EggShell_GetVIState(TypeManagerRef tm)
 
 VIREO_EXPORT void EggShell_ResumeVIPreWork(TypeManagerRef tm)
 {
-    return tm->TheExecutionContext()->FillRunningQueue();
+    return tm->TheExecutionContext()->setVIState(1);
 }
 
 VIREO_EXPORT void EggShell_PauseExecutionContext(TypeManagerRef tm)

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -47,14 +47,12 @@ VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, In
 
 VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID)
 {
-    SubString objectString(objectID);
-    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectString);
+    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectID);
 }
 
 VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state)
 {
-    SubString objectString(objectID);
-    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectString, state);
+    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectID, state);
 }
 
 //------------------------------------------------------------

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -45,14 +45,16 @@ VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, In
     return tm->TheExecutionContext()->ExecuteSlices(numSlices, millisecondsToRun);
 }
 
-VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, SubString objectID)
+VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID)
 {
-    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectID);
+    SubString objectString(objectID);
+    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectString);
 }
 
-VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, SubString objectID, Boolean state)
+VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state)
 {
-    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectID, state);
+    SubString objectString(objectID);
+    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectString, state);
 }
 
 //------------------------------------------------------------

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -45,14 +45,39 @@ VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, In
     return tm->TheExecutionContext()->ExecuteSlices(numSlices, millisecondsToRun);
 }
 
-VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, SubString objectID)
+VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID)
 {
     return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectID);
 }
 
-VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, SubString objectID, Boolean state)
+VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state)
 {
     tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectID, state);
+}
+
+VIREO_EXPORT Boolean EggShell_GetBreakPointState(TypeManagerRef tm, const char* objectID)
+{
+    return tm->TheExecutionContext()->debuggingContext->GetBreakPointState(objectID);
+}
+
+VIREO_EXPORT void EggShell_SetBreakPointState(TypeManagerRef tm, const char* objectID, Boolean state)
+{
+      tm->TheExecutionContext()->debuggingContext->SetBreakPointState(objectID, state);
+}
+
+VIREO_EXPORT Int32 EggShell_GetVIState(TypeManagerRef tm)
+{
+    return tm->TheExecutionContext()->getVIPauseState();
+}
+
+VIREO_EXPORT void EggShell_ResumeVIPreWork(TypeManagerRef tm)
+{
+    return tm->TheExecutionContext()->FillRunningQueue();
+}
+
+VIREO_EXPORT void EggShell_PauseExecutionContext(TypeManagerRef tm)
+{
+    return tm->TheExecutionContext()->PauseExecutionContext();
 }
 
 //------------------------------------------------------------

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -15,14 +15,11 @@ namespace Vireo {
     {
 #if kVireoOS_emscripten
       if (THREAD_EXEC()->debuggingContext->GetBreakPointState((const char*)_Param(0)->Begin())) {
-            THREAD_EXEC()->setVIState(2);
             jsDebuggingContextBreakPointInterrupt(_Param(0));
-            THREAD_EXEC()->CopyAndEmptyRunningQueue(_NextInstruction());
-            return THREAD_EXEC()->Stop();
+            return THREAD_EXEC()->Pause(_NextInstruction());
         }
       if (THREAD_EXEC()->getVIPauseState() == 2){
-          THREAD_EXEC()->CopyAndEmptyRunningQueue(_NextInstruction());
-          return THREAD_EXEC()->Stop();
+          return THREAD_EXEC()->Pause(_NextInstruction());
       }
 #endif
         return _NextInstruction();

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -13,7 +13,7 @@ namespace Vireo {
     // Debug node which will check if breakpoint is set or not
     VIREO_FUNCTION_SIGNATURE1(DebugPoint, StringRef)
     {
-        if (THREAD_EXEC()->debuggingContext->GetDebugPointState(_Param(0)->MakeSubStringAlias())) {
+        if (THREAD_EXEC()->debuggingContext->GetDebugPointState((const char*)_Param(0)->Begin())) {
 #if kVireoOS_emscripten
             jsDebuggingContextDebugPointInterrupt(_Param(0));
 #endif

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -10,19 +10,21 @@
 
 namespace Vireo {
     //------------------------------------------------------------
-    // Debug node which will check if breakpoint is set or not and do return cildsac for VI pause state
+    // Debug node which will check if breakpoint is set or not and do return culdsac for VI pause state
     VIREO_FUNCTION_SIGNATURE1(DebugPoint, StringRef)
     {
-        if (THREAD_EXEC()->debuggingContext->GetDebugPointState(_Param(0)->MakeSubStringAlias())) {
 #if kVireoOS_emscripten
-            THREAD_EXEC()->setVIPauseState(false);
-            THREAD_EXEC()->ExecuteAllClumpsTillNextDebugPoint();
-            jsDebuggingContextDebugPointInterrupt(_Param(0));
+      if (THREAD_EXEC()->debuggingContext->GetBreakPointState((const char*)_Param(0)->Begin())) {
+            THREAD_EXEC()->setVIState(2);
+            jsDebuggingContextBreakPointInterrupt(_Param(0));
+            THREAD_EXEC()->CopyAndEmptyRunningQueue(_NextInstruction());
+            return THREAD_EXEC()->Stop();
+        }
+      if (THREAD_EXEC()->getVIPauseState() == 2){
+          THREAD_EXEC()->CopyAndEmptyRunningQueue(_NextInstruction());
+          return THREAD_EXEC()->Stop();
+      }
 #endif
-        }
-        if (THREAD_EXEC()->getVIPauseState()) {
-           return _this;
-        }
         return _NextInstruction();
     }
 

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -6,7 +6,6 @@
 
 #if kVireoOS_emscripten
 #include <emscripten.h>
-#include "ExecutionContext.cpp"
 #endif
 
 namespace Vireo {
@@ -16,15 +15,15 @@ namespace Vireo {
     {
         if (THREAD_EXEC()->debuggingContext->GetDebugPointState(_Param(0)->MakeSubStringAlias())) {
 #if kVireoOS_emscripten
-			THREAD_EXEC()->_viPaused = true;
-			THREAD_EXEC()->ExecuteTillNextStopPoint();
+            THREAD_EXEC()->_viPaused = true;
+            THREAD_EXEC()->ExecuteTillNextStopPoint();
             jsDebuggingContextDebugPointInterrupt(_Param(0));
 #endif
         }
-		if (THREAD_EXEC()->_viPaused) {
-			return _this;
-		}
-		return _NextInstruction();
+        if (THREAD_EXEC()->_viPaused) {
+            return _this;
+        }
+        return _NextInstruction();
     }
 
     DEFINE_VIREO_BEGIN(Execution)

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -15,13 +15,13 @@ namespace Vireo {
     {
         if (THREAD_EXEC()->debuggingContext->GetDebugPointState(_Param(0)->MakeSubStringAlias())) {
 #if kVireoOS_emscripten
-            THREAD_EXEC()->_viPaused = true;
-            THREAD_EXEC()->ExecuteTillNextStopPoint();
+            THREAD_EXEC()->setVIPauseState(false);
+            THREAD_EXEC()->ExecuteAllClumpsTillNextDebugPoint();
             jsDebuggingContextDebugPointInterrupt(_Param(0));
 #endif
         }
-        if (THREAD_EXEC()->_viPaused) {
-            return _this;
+        if (THREAD_EXEC()->getVIPauseState()) {
+           return _this;
         }
         return _NextInstruction();
     }

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -6,19 +6,25 @@
 
 #if kVireoOS_emscripten
 #include <emscripten.h>
+#include "ExecutionContext.cpp"
 #endif
 
 namespace Vireo {
     //------------------------------------------------------------
-    // Debug node which will check if breakpoint is set or not
+    // Debug node which will check if breakpoint is set or not and do return cildsac for VI pause state
     VIREO_FUNCTION_SIGNATURE1(DebugPoint, StringRef)
     {
         if (THREAD_EXEC()->debuggingContext->GetDebugPointState(_Param(0)->MakeSubStringAlias())) {
 #if kVireoOS_emscripten
+			THREAD_EXEC()->_viPaused = true;
+			THREAD_EXEC()->ExecuteTillNextStopPoint();
             jsDebuggingContextDebugPointInterrupt(_Param(0));
 #endif
         }
-        return _NextInstruction();
+		if (THREAD_EXEC()->_viPaused) {
+			return _this;
+		}
+		return _NextInstruction();
     }
 
     DEFINE_VIREO_BEGIN(Execution)

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -452,20 +452,20 @@ Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, Int3
 //------------------------------------------------------------
 void ExecutionContext::ExecuteTillNextStopPoint()
 {
-	int sizeOfQueue = _runQueue.size();
-	while (sizeOfQueue > 0)
-	{
-		VIClump*  clump = _runQueue.Dequeue();
-		InstructionCore* currentInstruction = _runningQueueElt ? _runningQueueElt->_savePc : nullptr;
-		InstructionCore* nextInstruction = nullptr;
-		while (nextInstruction != &_culDeSac) {
-			currentInstruction = nextInstruction ? nextInstruction : currentInstruction;
-			nextInstruction = _PROGMEM_PTR(currentInstruction, _function)(currentInstruction);
-		}
-		clump->_savePc = currentInstruction;
-		_runQueue.Enqueue(clump);
-		sizeOfQueue--;
-	}
+    int sizeOfQueue = _runQueue.size();
+    while (sizeOfQueue > 0)
+    {
+        VIClump*  clump = _runQueue.Dequeue();
+        InstructionCore* currentInstruction = _runningQueueElt ? _runningQueueElt->_savePc : nullptr;
+        InstructionCore* nextInstruction = nullptr;
+        while (nextInstruction != &_culDeSac) {
+            currentInstruction = nextInstruction ? nextInstruction : currentInstruction;
+            nextInstruction = _PROGMEM_PTR(currentInstruction, _function)(currentInstruction);
+        }
+        clump->_savePc = currentInstruction;
+        _runQueue.Enqueue(clump);
+        sizeOfQueue--;
+    }
 }
 //------------------------------------------------------------
 void ExecutionContext::EnqueueRunQueue(VIClump* elt)

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -29,6 +29,7 @@ _PROGMEM InstructionCore ExecutionContext::_culDeSac;
 #ifdef VIREO_SINGLE_GLOBAL_CONTEXT
 TypeManagerRef  ExecutionContext::_theTypeManager;
 VIClumpQueue    ExecutionContext::_runQueue;            // Elts ready To run
+VIClumpQueue    ExecutionContext::_waitQueue
 VIClump*        ExecutionContext::_sleepingList;        // Elts waiting for something external to wake them up
 VIClump*        ExecutionContext::_runningQueueElt;     // Elt actually running
 Int32           ExecutionContext::_breakoutCount;
@@ -329,6 +330,32 @@ InstructionCore* ExecutionContext::SuspendRunningQueueElt(InstructionCore* nextI
     }
 }
 
+void ExecutionContext::CopyAndEmptyRunningQueue(InstructionCore* nextInClump)
+{
+    VIREO_ASSERT(nullptr != _runningQueueElt)
+
+    _runningQueueElt->_savePc = nextInClump;
+    _waitQueue.Enqueue(_runningQueueElt);
+    while ((_runningQueueElt != nullptr)){
+        _runningQueueElt = _runQueue.Dequeue();
+        _waitQueue.Enqueue(_runningQueueElt);
+    }
+}
+
+void ExecutionContext::PauseExecutionContext(){
+    setVIState(2);
+}
+
+void ExecutionContext::FillRunningQueue()
+{
+    VIClump*  clump;
+    clump = (_waitQueue).Dequeue();
+    while (clump != nullptr){
+        _runQueue.Enqueue(clump);
+        clump = (_waitQueue).Dequeue();
+    }
+    setVIState(1);
+}
 
 //------------------------------------------------------------
 // ExecuteSlices - execute instructions in run queue repeatedly (numSlices at a time before breaking out and checking
@@ -446,6 +473,9 @@ Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, Int3
     if (reply == kExecSlices_ClumpsFinished) {
         RunCleanupProcs(nullptr);  // Cleans up all control refs when top VI finishes (refs not associated with the completion of the VI they are linked to).
     }
+    if (reply == kExecSlices_ClumpsFinished && getVIPauseState() != 2){
+        setVIState(0);
+    }
 
     return reply;
 }
@@ -482,6 +512,16 @@ void ExecutionContext::LogEvent(EventLog::EventSeverity severity, ConstCStr mess
     va_start(args, message);
     tempLog.LogEventV(severity, -1, message, args);
     va_end(args);
+}
+//------------------------------------------------------------
+Int32 ExecutionContext::getVIPauseState()
+{
+    return _viPaused;
+}
+//-----------------------------------------------------------
+void ExecutionContext::setVIState(Int32 viState)
+{
+    _viPaused = viState;
 }
 //------------------------------------------------------------
 #ifdef VIVM_SUPPORTS_ISR

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -450,7 +450,7 @@ Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, Int3
     return reply;
 }
 //------------------------------------------------------------
-void ExecutionContext::ExecuteTillNextStopPoint()
+void ExecutionContext::ExecuteAllClumpsTillNextDebugPoint()
 {
     int sizeOfQueue = _runQueue.size();
     while (sizeOfQueue > 0)

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -450,6 +450,24 @@ Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, Int3
     return reply;
 }
 //------------------------------------------------------------
+void ExecutionContext::ExecuteTillNextStopPoint()
+{
+	int sizeOfQueue = _runQueue.size();
+	while (sizeOfQueue > 0)
+	{
+		VIClump*  clump = _runQueue.Dequeue();
+		InstructionCore* currentInstruction = _runningQueueElt ? _runningQueueElt->_savePc : nullptr;
+		InstructionCore* nextInstruction = nullptr;
+		while (nextInstruction != &_culDeSac) {
+			currentInstruction = nextInstruction ? nextInstruction : currentInstruction;
+			nextInstruction = _PROGMEM_PTR(currentInstruction, _function)(currentInstruction);
+		}
+		clump->_savePc = currentInstruction;
+		_runQueue.Enqueue(clump);
+		sizeOfQueue--;
+	}
+}
+//------------------------------------------------------------
 void ExecutionContext::EnqueueRunQueue(VIClump* elt)
 {
     VIREO_ASSERT((nullptr == elt->_next))

--- a/source/core/Queue.cpp
+++ b/source/core/Queue.cpp
@@ -57,15 +57,15 @@ VIClump* VIClumpQueue::Dequeue()
 
     return head;
 }
-//size of queque
+// size of queque
 int VIClumpQueue::size()
 {
-	int numberOfElements = 0;
-	VIClumpQueue* temp = this;
-	while (temp->_head != nullptr) {
-		temp->_head = temp->_head->_next;
-		numberOfElements++;
-	}
-	return numberOfElements;
+    int numberOfElements = 0;
+    VIClumpQueue* temp = this;
+    while (temp->_head != nullptr) {
+        temp->_head = temp->_head->_next;
+        numberOfElements++;
+    }
+    return numberOfElements;
 }
 }  // namespace Vireo

--- a/source/core/Queue.cpp
+++ b/source/core/Queue.cpp
@@ -61,9 +61,9 @@ VIClump* VIClumpQueue::Dequeue()
 int VIClumpQueue::size()
 {
     int numberOfElements = 0;
-    VIClumpQueue* temp = this;
-    while (temp->_head != nullptr) {
-        temp->_head = temp->_head->_next;
+    VIClumpQueue temp = *this;
+    while (temp._head != nullptr) {
+        temp._head = temp._head->_next;
         numberOfElements++;
     }
     return numberOfElements;

--- a/source/core/Queue.cpp
+++ b/source/core/Queue.cpp
@@ -57,5 +57,15 @@ VIClump* VIClumpQueue::Dequeue()
 
     return head;
 }
-
+//size of queque
+int VIClumpQueue::size()
+{
+	int numberOfElements = 0;
+	VIClumpQueue* temp = this;
+	while (temp->_head != nullptr) {
+		temp->_head = temp->_head->_next;
+		numberOfElements++;
+	}
+	return numberOfElements;
+}
 }  // namespace Vireo

--- a/source/core/library_coreHelpers.js
+++ b/source/core/library_coreHelpers.js
@@ -12,6 +12,9 @@
         },
         jsDebuggingContextDebugPointInterrupt: function () {
             Module.coreHelpers.jsDebuggingContextDebugPointInterrupt.apply(undefined, arguments);
+        },
+        jsDebuggingContextBreakPointInterrupt: function () {
+            Module.coreHelpers.jsDebuggingContextBreakPointInterrupt.apply(undefined, arguments);
         }
     };
 

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -21,6 +21,11 @@ var assignCoreHelpers;
             // Dummy noop function user can replace by using eggShell.setDebugPointInterruptFunction
         };
 
+        // Private Instance Variables (per vireo instance)
+        var breakPointInterrupt = function (/* debugPointIdStr*/) {
+            // Dummy noop function user can replace by using eggShell.setBreakPointInterruptFunction
+        };
+
         var CODES = {
             NO_ERROR: 0
         };
@@ -34,6 +39,11 @@ var assignCoreHelpers;
         Module.coreHelpers.jsDebuggingContextDebugPointInterrupt = function (debugPointIdentifierStringPointer) {
             var debugPointIdentifierString = Module.eggShell.dataReadString(debugPointIdentifierStringPointer);
             debugPointInterrupt(debugPointIdentifierString);
+        };
+
+        Module.coreHelpers.jsDebuggingContextBreakPointInterrupt = function (debugPointIdentifierStringPointer) {
+            var debugPointIdentifierString = Module.eggShell.dataReadString(debugPointIdentifierStringPointer);
+            breakPointInterrupt(debugPointIdentifierString);
         };
 
         Module.coreHelpers.jsSystemLogging_WriteMessageUTF8 = function (
@@ -72,6 +82,13 @@ var assignCoreHelpers;
                 throw new Error('Probe must be a callable function');
             }
             debugPointInterrupt = fn;
+        };
+
+        publicAPI.coreHelpers.setBreakPointInterruptFunction = function (fn) {
+            if (typeof fn !== 'function') {
+                throw new Error('breakpoint must be a callable function');
+            }
+            breakPointInterrupt = fn;
         };
 
         // Returns the length of a C string (excluding null terminator)

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -57,8 +57,8 @@ VIREO_EXPORT Int32 Data_GetStringLength(StringRef stringObject);
 VIREO_EXPORT void* Data_GetArrayBegin(const void* pData);
 VIREO_EXPORT void Data_GetArrayDimensions(const void* pData, IntIndex dimensionsLengths[]);
 VIREO_EXPORT Int32 Data_GetArrayLength(const void* pData);
-VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, SubString objectID, Boolean state);
-VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, SubString objectID);
+VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state);
+VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID);
 //------------------------------------------------------------
 //! Typeref functions
 VIREO_EXPORT TypeRef TypeManager_Define(TypeManagerRef typeManager, const char* typeName, const char* typeString);

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -57,8 +57,13 @@ VIREO_EXPORT Int32 Data_GetStringLength(StringRef stringObject);
 VIREO_EXPORT void* Data_GetArrayBegin(const void* pData);
 VIREO_EXPORT void Data_GetArrayDimensions(const void* pData, IntIndex dimensionsLengths[]);
 VIREO_EXPORT Int32 Data_GetArrayLength(const void* pData);
-VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, SubString objectID, Boolean state);
-VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, SubString objectID);
+VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state);
+VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID);
+VIREO_EXPORT void EggShell_SetBreakPointState(TypeManagerRef tm, const char* objectID, Boolean state);
+VIREO_EXPORT Boolean EggShell_GetBreakPointState(TypeManagerRef tm, const char* objectID);
+VIREO_EXPORT Int32 EggShell_GetVIState(TypeManagerRef tm);
+VIREO_EXPORT void ResumeVIPreWork(TypeManagerRef tm);
+VIREO_EXPORT void PauseExecutionContext(TypeManagerRef tm);
 //------------------------------------------------------------
 //! Typeref functions
 VIREO_EXPORT TypeRef TypeManager_Define(TypeManagerRef typeManager, const char* typeName, const char* typeString);

--- a/source/include/DebuggingContext.h
+++ b/source/include/DebuggingContext.h
@@ -19,29 +19,49 @@ namespace Vireo
     extern "C" {
         extern void jsDebuggingContextDebugPointInterrupt(StringRef);
     }
+    extern "C" {
+        extern void jsDebuggingContextBreakPointInterrupt(StringRef);
+    }
 #endif
 
 class DebuggingContext
 {
  private:
-    std::map<SubString, bool, CompareSubString> _debugPointState;
- public:
-    bool GetDebugPointState(SubString objectID)
-    {
-         typedef std::map<SubString, bool>::iterator iterator;
-         iterator it = _debugPointState.find(objectID);
+    std::map<const char*, bool> _debugPointState;
+    std::map<const char*, bool> _breakPointState;
 
-         if (it == _debugPointState.end()) {
-         // error out:  std::cout << "Key-value pair not present in map";
-              return false;
-         }
-        return it->second;
+ public:
+    bool GetDebugPointState(const char* objectID)
+    {
+        for (auto itr : _debugPointState)
+        {
+            if (strcmp(itr.first, objectID) == 0)
+            {
+                return itr.second;
+            }
+        }
+        return false;
     }
-    void SetDebugPointState(SubString objectID, bool state)
+    void SetDebugPointState(const char* objectID, bool state)
     {
          _debugPointState[objectID] = state;
+    }
+    bool GetBreakPointState(const char* objectID)
+    {
+        for (auto itr : _breakPointState)
+        {
+            if (strcmp(itr.first, objectID) == 0)
+            {
+                return itr.second;
+            }
+        }
+        return false;
+    }
+    void SetBreakPointState(const char* objectID, bool state)
+    {
+         _breakPointState[objectID] = state;
     }
 };
 }  // namespace Vireo
 
-#endif // ! _DEBUGGINGCONTEXT_H
+#endif  // ! _DEBUGGINGCONTEXT_H

--- a/source/include/DebuggingContext.h
+++ b/source/include/DebuggingContext.h
@@ -24,20 +24,20 @@ namespace Vireo
 class DebuggingContext
 {
  private:
-    std::map<SubString, bool, CompareSubString> _debugPointState;
+    std::map<const char*, bool> _debugPointState;
  public:
-    bool GetDebugPointState(SubString objectID)
+    bool GetDebugPointState(const char* objectID)
     {
-         typedef std::map<SubString, bool>::iterator iterator;
-         iterator it = _debugPointState.find(objectID);
-
-         if (it == _debugPointState.end()) {
-         // error out:  std::cout << "Key-value pair not present in map";
-              return false;
-         }
-        return it->second;
+        for (auto itr : _debugPointState)
+        {
+            if (strcmp(itr.first, objectID) == 0)
+            {
+                return itr.second;
+            }
+        }
+        return false;
     }
-    void SetDebugPointState(SubString objectID, bool state)
+    void SetDebugPointState(const char* objectID, bool state)
     {
          _debugPointState[objectID] = state;
     }

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -91,11 +91,10 @@ class ExecutionContext
  private:
     ECONTEXT    VIClumpQueue    _runQueue;         // Clumps ready to run
     ECONTEXT    Int32           _breakoutCount;   // Inner execution loop "breaks out" when this gets to 0
-
+    ECONTEXT    Boolean          _viPaused = false;
  public:
     ECONTEXT    Timer           _timer;           // TODO(PaulAustin): can be moved out of the execcontext once
                                                  // instruction can take injected parameters.
-    ECONTEXT    Boolean          _viPaused = false;
 #ifdef VIREO_SUPPORTS_ISR
     ECONTEXT    VIClump*        _triggeredIsrList;  // Elts waiting for something external to wake them up
     ECONTEXT    void            IsrEnqueue(QueueElt* elt);
@@ -112,14 +111,15 @@ class ExecutionContext
     ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* nextInClump);
     ECONTEXT    InstructionCore* Stop();
     ECONTEXT    void            ClearBreakout() { _breakoutCount = 0; }
-    ECONTEXT    void            ExecuteTillNextStopPoint();
+    ECONTEXT    void            ExecuteAllClumpsTillNextDebugPoint();
     ECONTEXT    void            EnqueueRunQueue(VIClump* elt);
     ECONTEXT    VIClump*        _runningQueueElt;    // Element actually running
     ECONTEXT DebuggingContext* debuggingContext;
  public:
     // Method for runtime errors to be routed through.
     ECONTEXT    void            LogEvent(EventLog::EventSeverity severity, ConstCStr message, ...) const;
-
+    ECONTEXT Boolean getVIPauseState();
+    ECONTEXT void setVIPauseState(Boolean pauseState);
  private:
     static Boolean _classInited;
     static InstructionCore _culDeSac;

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -90,8 +90,9 @@ class ExecutionContext
     ~ExecutionContext();
  private:
     ECONTEXT    VIClumpQueue    _runQueue;         // Clumps ready to run
+    ECONTEXT    VIClumpQueue    _waitQueue;
     ECONTEXT    Int32           _breakoutCount;   // Inner execution loop "breaks out" when this gets to 0
-    ECONTEXT    Boolean          _viPaused = false;
+    ECONTEXT    Int32          _viPaused = 1;
  public:
     ECONTEXT    Timer           _timer;           // TODO(PaulAustin): can be moved out of the execcontext once
                                                  // instruction can take injected parameters.
@@ -109,17 +110,20 @@ class ExecutionContext
     // Run the concurrent execution system for a short period of time
     ECONTEXT    Int32 /*ExecSlicesResult*/ ExecuteSlices(Int32 numSlices, Int32 millisecondsToRun);
     ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* nextInClump);
+    ECONTEXT    void             PauseExecutionContext();
     ECONTEXT    InstructionCore* Stop();
     ECONTEXT    void            ClearBreakout() { _breakoutCount = 0; }
     ECONTEXT    void            ExecuteAllClumpsTillNextDebugPoint();
     ECONTEXT    void            EnqueueRunQueue(VIClump* elt);
+    ECONTEXT    void            CopyAndEmptyRunningQueue(InstructionCore* nextInClump);
+    ECONTEXT    void            FillRunningQueue();
     ECONTEXT    VIClump*        _runningQueueElt;    // Element actually running
     ECONTEXT DebuggingContext* debuggingContext;
  public:
     // Method for runtime errors to be routed through.
     ECONTEXT    void            LogEvent(EventLog::EventSeverity severity, ConstCStr message, ...) const;
-    ECONTEXT Boolean getVIPauseState();
-    ECONTEXT void setVIPauseState(Boolean pauseState);
+    ECONTEXT Int32              getVIPauseState();
+    ECONTEXT void               setVIState(Int32 pauseState);
  private:
     static Boolean _classInited;
     static InstructionCore _culDeSac;

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -51,7 +51,7 @@ class VIClumpQueue
     Boolean IsEmpty() const { return (this->_head == nullptr); }
     VIClump* Dequeue();
     void Enqueue(VIClump* elt);
-	int size();
+    int size();
 };
 
 enum ExecSlicesResult {

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -55,6 +55,7 @@ class VIClumpQueue
 };
 
 enum ExecSlicesResult {
+    kExecSlices_ExecutionPaused = -3,
     kExecSlices_ClumpsWaiting = -2,     // Clumps waiting, but for less than 1 ms; call executeSlices again ASAP
     kExecSlices_ClumpsInRunQueue = -1,  // Clumps ready to run in run queue; call executeSlices again ASAP
     kExecSlices_ClumpsFinished = 0,     // All clumps done executing, nothing waiting on timers.  VI done.
@@ -90,7 +91,6 @@ class ExecutionContext
     ~ExecutionContext();
  private:
     ECONTEXT    VIClumpQueue    _runQueue;         // Clumps ready to run
-    ECONTEXT    VIClumpQueue    _waitQueue;
     ECONTEXT    Int32           _breakoutCount;   // Inner execution loop "breaks out" when this gets to 0
     ECONTEXT    Int32          _viPaused = 1;
  public:
@@ -112,11 +112,10 @@ class ExecutionContext
     ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* nextInClump);
     ECONTEXT    void             PauseExecutionContext();
     ECONTEXT    InstructionCore* Stop();
+    ECONTEXT    InstructionCore* Pause(InstructionCore* nextInstruction);
     ECONTEXT    void            ClearBreakout() { _breakoutCount = 0; }
     ECONTEXT    void            ExecuteAllClumpsTillNextDebugPoint();
     ECONTEXT    void            EnqueueRunQueue(VIClump* elt);
-    ECONTEXT    void            CopyAndEmptyRunningQueue(InstructionCore* nextInClump);
-    ECONTEXT    void            FillRunningQueue();
     ECONTEXT    VIClump*        _runningQueueElt;    // Element actually running
     ECONTEXT DebuggingContext* debuggingContext;
  public:

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -51,6 +51,7 @@ class VIClumpQueue
     Boolean IsEmpty() const { return (this->_head == nullptr); }
     VIClump* Dequeue();
     void Enqueue(VIClump* elt);
+	int size();
 };
 
 enum ExecSlicesResult {
@@ -94,6 +95,7 @@ class ExecutionContext
  public:
     ECONTEXT    Timer           _timer;           // TODO(PaulAustin): can be moved out of the execcontext once
                                                  // instruction can take injected parameters.
+    ECONTEXT    Boolean          _viPaused = false;
 #ifdef VIREO_SUPPORTS_ISR
     ECONTEXT    VIClump*        _triggeredIsrList;  // Elts waiting for something external to wake them up
     ECONTEXT    void            IsrEnqueue(QueueElt* elt);
@@ -110,6 +112,7 @@ class ExecutionContext
     ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* nextInClump);
     ECONTEXT    InstructionCore* Stop();
     ECONTEXT    void            ClearBreakout() { _breakoutCount = 0; }
+    ECONTEXT    void            ExecuteTillNextStopPoint();
     ECONTEXT    void            EnqueueRunQueue(VIClump* elt);
     ECONTEXT    VIClump*        _runningQueueElt;    // Element actually running
     ECONTEXT DebuggingContext* debuggingContext;

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -679,11 +679,13 @@ var assignEggShell;
         };
 
         Module.eggShell.getDebugPointState = publicAPI.eggShell.getDebugPointState = function (objectID) {
-            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectID);
+            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer);
         };
 
         Module.eggShell.setDebugPointState = publicAPI.eggShell.setDebugPointState = function (objectID, state) {
-            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectID, state);
+            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer, state);
         };
 
         Module.eggShell.loadVia = publicAPI.eggShell.loadVia = function (viaText, isDebuggingEnabled = false) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -679,13 +679,13 @@ var assignEggShell;
         };
 
         Module.eggShell.getDebugPointState = publicAPI.eggShell.getDebugPointState = function (objectID) {
-            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
-            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer);
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectIdHeapPointer);
         };
 
         Module.eggShell.setDebugPointState = publicAPI.eggShell.setDebugPointState = function (objectID, state) {
-            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
-            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer, state);
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectIdHeapPointer, state);
         };
 
         Module.eggShell.loadVia = publicAPI.eggShell.loadVia = function (viaText, isDebuggingEnabled = false) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -679,11 +679,35 @@ var assignEggShell;
         };
 
         Module.eggShell.getDebugPointState = publicAPI.eggShell.getDebugPointState = function (objectID) {
-            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectID);
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectIdHeapPointer);
         };
 
         Module.eggShell.setDebugPointState = publicAPI.eggShell.setDebugPointState = function (objectID, state) {
-            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectID, state);
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectIdHeapPointer, state);
+        };
+
+        Module.eggShell.resumeVIPreWork = publicAPI.eggShell.resumeVIPreWork = function () {
+            Module._EggShell_ResumeVIPreWork(Module.eggShell.v_userShell);
+        };
+
+        Module.eggShell.pauseExecutionContext = publicAPI.eggShell.pauseExecutionContext = function () {
+            Module._EggShell_PauseExecutionContext(Module.eggShell.v_userShell);
+        };
+
+        Module.eggShell.getBreakPointState = publicAPI.eggShell.getBreakPointState = function (objectID) {
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            return Module._EggShell_GetBreakPointState(Module.eggShell.v_userShell, objectIdHeapPointer);
+        };
+
+        Module.eggShell.setBreakPointState = publicAPI.eggShell.setBreakPointState = function (objectID, state) {
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            Module._EggShell_SetBreakPointState(Module.eggShell.v_userShell, objectIdHeapPointer, state);
+        };
+
+        Module.eggShell.getVIState = publicAPI.eggShell.getVIState = function () {
+            return Module._EggShell_GetVIState(Module.eggShell.v_userShell);
         };
 
         Module.eggShell.loadVia = publicAPI.eggShell.loadVia = function (viaText, isDebuggingEnabled = false) {


### PR DESCRIPTION
- Added the following functions to access from the JS layer:
1. PauseExecutionContext
2. ResumeVIPreWork: 
3. GetVIState
4. SetBreakPointState: it will update the breakpoint map which has debug node breakpoint status
5. GetBreakPointState: used to get breakpoint status for given debug node id

- On breakpoint hit the execution context set the VI state to 2 (paused) and call the interrupt extern function then it will empty the running queue (by making a copy to wait queue) and stop the execution.
- On Resume: we will reload the run queue from wait queue and change the vI pause state to 1 (running).
- On pause: It will set the VI state to 2 (paused)
- Also during each debug node it checks for VI state is paused and if yes it will empty the running queue (by making a copy to wait queue) and stop the execution.
