### PR TITLE
Fix segmentation faults in DebugPointAPIs

### DIFF
--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -45,14 +45,16 @@ VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, In
     return tm->TheExecutionContext()->ExecuteSlices(numSlices, millisecondsToRun);
 }
 
-VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, SubString objectID)
+VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID)
 {
-    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectID);
+    SubString objectString(objectID);
+    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectString);
 }
 
-VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, SubString objectID, Boolean state)
+VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state)
 {
-    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectID, state);
+    SubString objectString(objectID);
+    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectString, state);
 }
 
 //------------------------------------------------------------

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -57,8 +57,8 @@ VIREO_EXPORT Int32 Data_GetStringLength(StringRef stringObject);
 VIREO_EXPORT void* Data_GetArrayBegin(const void* pData);
 VIREO_EXPORT void Data_GetArrayDimensions(const void* pData, IntIndex dimensionsLengths[]);
 VIREO_EXPORT Int32 Data_GetArrayLength(const void* pData);
-VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, SubString objectID, Boolean state);
-VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, SubString objectID);
+VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state);
+VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID);
 //------------------------------------------------------------
 //! Typeref functions
 VIREO_EXPORT TypeRef TypeManager_Define(TypeManagerRef typeManager, const char* typeName, const char* typeString);

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -679,11 +679,13 @@ var assignEggShell;
         };
 
         Module.eggShell.getDebugPointState = publicAPI.eggShell.getDebugPointState = function (objectID) {
-            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectID);
+            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer);
         };
 
         Module.eggShell.setDebugPointState = publicAPI.eggShell.setDebugPointState = function (objectID, state) {
-            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectID, state);
+            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer, state);
         };
 
         Module.eggShell.loadVia = publicAPI.eggShell.loadVia = function (viaText, isDebuggingEnabled = false) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -679,13 +679,13 @@ var assignEggShell;
         };
 
         Module.eggShell.getDebugPointState = publicAPI.eggShell.getDebugPointState = function (objectID) {
-            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
-            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer);
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            return Module._EggShell_GetDebugPointState(Module.eggShell.v_userShell, objectIdHeapPointer);
         };
 
         Module.eggShell.setDebugPointState = publicAPI.eggShell.setDebugPointState = function (objectID, state) {
-            var objectIdStackPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
-            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectIdStackPointer, state);
+            var objectIdHeapPointer = Module.coreHelpers.writeJSStringToHeap(objectID);
+            Module._EggShell_SetDebugPointState(Module.eggShell.v_userShell, objectIdHeapPointer, state);
         };
 
         Module.eggShell.loadVia = publicAPI.eggShell.loadVia = function (viaText, isDebuggingEnabled = false) {


### PR DESCRIPTION
While testing with the DebugPointAPIs, I ran into segmentation faults using the Set/GetDebuPoint APIs. The reason was how we were passing strings to the vireo layer. For strings we need to write the values into the typed array heap first and then pass the heap pointer to Vireo.