### PR TITLE
Fix for issues retrieving data in the debug point map

### DIFF
--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -47,14 +47,12 @@ VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, In
 
 VIREO_EXPORT Boolean EggShell_GetDebugPointState(TypeManagerRef tm, const char* objectID)
 {
-    SubString objectString(objectID);
-    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectString);
+    return tm->TheExecutionContext()->debuggingContext->GetDebugPointState(objectID);
 }
 
 VIREO_EXPORT void EggShell_SetDebugPointState(TypeManagerRef tm, const char* objectID, Boolean state)
 {
-    SubString objectString(objectID);
-    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectString, state);
+    tm->TheExecutionContext()->debuggingContext->SetDebugPointState(objectID, state);
 }
 
 //------------------------------------------------------------

--- a/source/core/DebugPoint.cpp
+++ b/source/core/DebugPoint.cpp
@@ -13,7 +13,7 @@ namespace Vireo {
     // Debug node which will check if breakpoint is set or not
     VIREO_FUNCTION_SIGNATURE1(DebugPoint, StringRef)
     {
-        if (THREAD_EXEC()->debuggingContext->GetDebugPointState(_Param(0)->MakeSubStringAlias())) {
+        if (THREAD_EXEC()->debuggingContext->GetDebugPointState((const char*)_Param(0)->Begin())) {
 #if kVireoOS_emscripten
             jsDebuggingContextDebugPointInterrupt(_Param(0));
 #endif

--- a/source/include/DebuggingContext.h
+++ b/source/include/DebuggingContext.h
@@ -24,20 +24,20 @@ namespace Vireo
 class DebuggingContext
 {
  private:
-    std::map<SubString, bool, CompareSubString> _debugPointState;
+    std::map<const char*, bool> _debugPointState;
  public:
-    bool GetDebugPointState(SubString objectID)
+    bool GetDebugPointState(const char* objectID)
     {
-         typedef std::map<SubString, bool>::iterator iterator;
-         iterator it = _debugPointState.find(objectID);
-
-         if (it == _debugPointState.end()) {
-         // error out:  std::cout << "Key-value pair not present in map";
-              return false;
-         }
-        return it->second;
+        for (auto itr : _debugPointState)
+        {
+            if (strcmp(itr.first, objectID) == 0)
+            {
+                return itr.second;
+            }
+        }
+        return false;
     }
-    void SetDebugPointState(SubString objectID, bool state)
+    void SetDebugPointState(const char* objectID, bool state)
     {
          _debugPointState[objectID] = state;
     }


### PR DESCRIPTION
The problem was that we were inserting the SubString class in the debug point map which isn't valid anymore when we actually access the map to read the debug point entries. Changed the map to store a pointer instead to the char array which would have been allocated by the js egg shell set debug point API [here](https://github.com/shivaprasad-basavaraj/VireoSDK/blob/b24813c524fcafe7f6209c95c35e2c0f4d4e0d3d/source/io/module_eggShell.js#L687).